### PR TITLE
Update OpenCV and Change LibMultiSense URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external/LibMultiSense"]
 	path = external/LibMultiSense
-	url = git@github.com:carnegierobotics/LibMultiSense.git
+	url = https://github.com/carnegierobotics/LibMultiSense.git

--- a/.hgignore
+++ b/.hgignore
@@ -1,4 +1,0 @@
-~$
-build/
-bin/
-lib/

--- a/src/MultiSenseWrapper.cpp
+++ b/src/MultiSenseWrapper.cpp
@@ -475,9 +475,9 @@ Mat MultiSenseWrapper::CopyLeftRectifiedRGB()
     // If we successfully generated a color image, rectify it now.
     if (!rgbImage.empty()) {
 
-        CvScalar OutlierColor = CV_RGB(0.0, 0.0, 0.0);
+        Scalar OutlierColor = CV_RGB(0.0, 0.0, 0.0);
         remap(rgbImage, rectifiedRgbImage, this->m_leftCalibrationMapX, this->m_leftCalibrationMapY,
-              CV_INTER_LINEAR, BORDER_CONSTANT, OutlierColor);
+              INTER_LINEAR, BORDER_CONSTANT, OutlierColor);
     }
 
     // The returned Mat will have zero size if we weren't able to get

--- a/src/TestMultiSenseWrapper.cpp
+++ b/src/TestMultiSenseWrapper.cpp
@@ -37,11 +37,11 @@ int main(int argc, char *argv[])
 
     // cvInitSystem(0, NULL);
     //cvNamedWindow("Rectified", CV_WINDOW_AUTOSIZE);
-    namedWindow("Disparity", CV_WINDOW_AUTOSIZE);
-    namedWindow("Left", CV_WINDOW_AUTOSIZE);
-    // namedWindow("Right", CV_WINDOW_AUTOSIZE);
-    namedWindow("Color", CV_WINDOW_AUTOSIZE);
-    namedWindow("Cloud", CV_WINDOW_AUTOSIZE);
+    namedWindow("Disparity", WINDOW_AUTOSIZE);
+    namedWindow("Left", WINDOW_AUTOSIZE);
+    // namedWindow("Right", WINDOW_AUTOSIZE);
+    namedWindow("Color", WINDOW_AUTOSIZE);
+    namedWindow("Cloud", WINDOW_AUTOSIZE);
 
 
     // Ask camera to start sending images


### PR DESCRIPTION
Add OpenCV 4.x compaitibility

Update the LibMultiSense submodule URL to use https instead of ssh so users do not need a github account to download submodules.